### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: SonarQube
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
 jobs:
   build:
     name: Build and analyze


### PR DESCRIPTION
Potential fix for [https://github.com/moha-tah/kanban-project/security/code-scanning/1](https://github.com/moha-tah/kanban-project/security/code-scanning/1)

The best way to fix this problem is to explicitly add a `permissions` block to the workflow. Since none of the steps requires write access to the repository, a minimal permissions set can be applied: `contents: read`. This can be done either at the root of the workflow (above `jobs:`), which will apply to all jobs, or at the job level (inside the `build:` job definition). Best practice is to set it at the root if all jobs are analysis-only, and at the job level if some jobs require different permissions. Since only one job (`build`) is present, adding it at the workflow root is recommended for simplicity. 

To implement this change, edit `.github/workflows/build.yml` and insert the following lines after the workflow `name:` and `on:` blocks, before `jobs:`:

```yaml
permissions:
  contents: read
```

No new imports or definitions are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
